### PR TITLE
Revamp countdown with retro styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,23 +8,36 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Funnel+Display:wght@300..800&display=swap" rel="stylesheet">
-    
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Oxanium:wght@300;400;700&display=swap" rel="stylesheet">
+
     <style>
+        :root {
+            --retro-bg: #0b0320;
+            --retro-bg-secondary: #1a0b3c;
+            --retro-panel: #271250;
+            --retro-panel-highlight: #432a93;
+            --retro-accent: #ff6ec7;
+            --retro-accent-secondary: #00f6ff;
+            --retro-text: #f9f7ff;
+            --retro-muted: rgba(255, 255, 255, 0.6);
+            --retro-shadow: rgba(0, 0, 0, 0.45);
+        }
         html {
             font-size: 14px;
-            font-family: "Funnel Display", sans-serif;
+            font-family: "Oxanium", "Funnel Display", sans-serif;
             font-weight: 400;
             font-style: normal;
         }
         body {
             margin: 0;
             font-size: 14px;
-            color: white;
+            color: var(--retro-text);
+            background: radial-gradient(circle at 20% 20%, rgba(255, 110, 199, 0.15), transparent 60%),
+                radial-gradient(circle at 80% 0%, rgba(0, 246, 255, 0.1), transparent 55%),
+                linear-gradient(160deg, var(--retro-bg) 0%, #120533 35%, #05000f 100%);
         }
-        @import url("https://fonts.googleapis.com/css2?family=Red+Hat+Text:wght@700&display=swap");
-
         .container.bg {
-            background-color: hsl(235, 16%, 14%);
+            background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, rgba(5, 0, 25, 0.85) 40%, rgba(12, 1, 36, 0.95) 100%);
             min-height: 100vh;
             background-repeat: no-repeat;
             background-position: top, bottom;
@@ -34,47 +47,94 @@
             align-items: center;
             flex-direction: column;
             position: relative;
+            overflow: hidden;
+        }
+
+        .container.bg::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background-image:
+                linear-gradient(rgba(0, 246, 255, 0.12) 1px, transparent 1px),
+                linear-gradient(90deg, rgba(0, 246, 255, 0.12) 1px, transparent 1px);
+            background-size: 120px 120px;
+            opacity: 0.45;
+            pointer-events: none;
+        }
+
+        .container.bg::after {
+            content: "";
+            position: absolute;
+            bottom: -25vh;
+            left: -10vw;
+            width: 120vw;
+            height: 70vh;
+            background: radial-gradient(circle at center, rgba(255, 110, 199, 0.35) 0%, rgba(67, 42, 147, 0.15) 35%, transparent 70%);
+            filter: blur(12px);
+            pointer-events: none;
         }
         .main-box {
             display: flex;
             flex-direction: column;
             align-items: center;
             margin: 10% 0;
+            padding: 2.5em clamp(1.5em, 4vw, 4em);
+            border-radius: 1.5em;
+            background: linear-gradient(145deg, rgba(39, 18, 80, 0.85) 0%, rgba(14, 4, 44, 0.75) 100%);
+            border: 2px solid rgba(0, 246, 255, 0.3);
+            box-shadow: 0 20px 50px rgba(5, 0, 35, 0.6), inset 0 0 35px rgba(255, 110, 199, 0.08);
+            backdrop-filter: blur(6px);
         }
         .heading {
-            font-size: 2em;
-            letter-spacing: 0.5rem;
+            font-family: "Press Start 2P", cursive;
+            font-size: clamp(1.4em, 3vw, 2.5em);
+            letter-spacing: 0.4rem;
+            text-transform: uppercase;
+            color: var(--retro-accent-secondary);
+            text-shadow: 0 0 8px rgba(0, 246, 255, 0.9), 0 0 18px rgba(0, 0, 0, 0.6);
+            margin-bottom: 1.5em;
         }
         .box {
             display: flex;
+            gap: clamp(1em, 2.5vw, 2.5em);
         }
         .card {
-            margin: 2em 0.5em;
+            margin: 2em 0;
             height: 150px;
             width: 150px;
             position: relative;
             perspective: 300px;
+            border-radius: 1em;
+            background: linear-gradient(160deg, rgba(67, 42, 147, 0.9) 0%, rgba(18, 4, 70, 0.9) 60%, rgba(9, 2, 35, 0.9) 100%);
+            box-shadow: 0 18px 35px var(--retro-shadow), 0 0 18px rgba(255, 110, 199, 0.25);
+            overflow: hidden;
+            border: 1px solid rgba(0, 246, 255, 0.2);
         }
         .card-flip {
-            background-color: hsl(236, 21%, 26%);
+            background: linear-gradient(160deg, rgba(16, 6, 45, 0.95) 0%, rgba(40, 21, 92, 0.95) 100%);
             height: 50%;
             width: 100%;
-            border-radius: 0.3em;
+            border-radius: 0.8em;
+            border: 1px solid rgba(0, 246, 255, 0.18);
         }
         .counter {
             position: absolute;
             font-size: 4em;
             font-weight: 800;
-            color: hsl(345, 95%, 68%);
+            color: var(--retro-accent);
+            text-shadow: 0 0 18px rgba(255, 110, 199, 0.7), 0 0 38px rgba(0, 246, 255, 0.45);
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
         }
         .denoters {
             text-align: center;
-            color: rgb(125 123 152);
+            color: var(--retro-muted);
             text-transform: uppercase;
-            font-size: 1.2em;
+            font-size: 1.1em;
+            letter-spacing: 0.4em;
+            margin-top: 1.3em;
+            text-shadow: 0 0 12px rgba(0, 0, 0, 0.6);
         }
         .flipper {
             animation: flip 0.3s;
@@ -86,16 +146,16 @@
             transition: 0.1s;
         }
         .card-flip.upper {
-            background: linear-gradient(to top, #2f3145c7, hsl(236, 21%, 26%) 88%);
+            background: linear-gradient(180deg, rgba(0, 246, 255, 0.1) 0%, rgba(16, 6, 45, 0.95) 40%, rgba(16, 6, 45, 1) 100%);
         }
         .card-flip.lower {
-            background: linear-gradient(to bottom, #242635c7, hsl(236, 21%, 26%) 88%);
+            background: linear-gradient(0deg, rgba(255, 110, 199, 0.18) 0%, rgba(40, 21, 92, 0.95) 50%, rgba(16, 6, 45, 1) 100%);
         }
         .card-flip.upper::after {
             content: "";
-            background: black;
-            height: 0.6em;
-            width: 0.6em;
+            background: linear-gradient(135deg, rgba(0, 246, 255, 0.6), rgba(0, 246, 255, 0));
+            height: 0.75em;
+            width: 0.75em;
             position: absolute;
             border-top-right-radius: 2em;
             border-bottom-right-radius: 2em;
@@ -105,9 +165,9 @@
         }
         .card-flip.lower::before {
             content: "";
-            background: black;
-            height: 0.6em;
-            width: 0.6em;
+            background: linear-gradient(135deg, rgba(255, 110, 199, 0.6), rgba(255, 110, 199, 0));
+            height: 0.75em;
+            width: 0.75em;
             position: absolute;
             border-top-left-radius: 2em;
             border-bottom-left-radius: 2em;
@@ -138,58 +198,76 @@
 
         /* Progress bar style */
         .progress-container {
-    width: 100%;
-    height: 10px;
-    background: 
-        hsl(235, 16%, 30%), /* Base background */
-        radial-gradient(circle, hsl(345, 95%, 68%) 10%, transparent 10%) repeat-x; /* Simulated dashed flight path */
-    border-radius: 10px;
-    margin-top: 2em;
-    position: relative;
-}
+            width: min(100%, 540px);
+            height: 12px;
+            background: rgba(6, 2, 22, 0.75);
+            border-radius: 999px;
+            margin-top: 2em;
+            position: relative;
+            border: 1px solid rgba(0, 246, 255, 0.3);
+            box-shadow: 0 0 16px rgba(0, 246, 255, 0.2), inset 0 0 20px rgba(255, 110, 199, 0.18);
+            overflow: hidden;
+        }
 
-.progress-bar {
-    height: 100%;
-    width: 0%;
-    background-color: hsl(345, 95%, 68%);
-    border-radius: 10px;
-    transition: width 1s ease-in-out;
-    position: relative;
-}
+        .progress-container::before {
+            content: "";
+            position: absolute;
+            inset: 2px;
+            border-radius: 999px;
+            background: repeating-linear-gradient(90deg, rgba(0, 246, 255, 0.15) 0, rgba(0, 246, 255, 0.15) 16px, transparent 16px, transparent 32px);
+            opacity: 0.45;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        .progress-bar {
+            height: 100%;
+            width: 0%;
+            background: linear-gradient(90deg, rgba(255, 110, 199, 0.8) 0%, rgba(0, 246, 255, 0.95) 60%, rgba(0, 246, 255, 0.75) 100%);
+            border-radius: 999px;
+            transition: width 1s ease-in-out;
+            position: relative;
+            box-shadow: 0 0 18px rgba(0, 246, 255, 0.75);
+            z-index: 1;
+        }
 
         .progress-bar::before {
-            content: '🎌';
+            content: '⬢';
             position: absolute;
-            top: -15px;
-            left: -30px;  /* Adjust as needed to position the flag */
-            width: 20px;
-            height: 20px;
-            background-size: cover;
+            top: -22px;
+            left: -18px;
+            font-family: "Press Start 2P", cursive;
+            font-size: 0.7rem;
+            color: rgba(0, 246, 255, 0.65);
+            text-shadow: 0 0 8px rgba(0, 246, 255, 0.9);
         }
         .progress-bar::after {
-            content: '🚀';
-            transform: rotate(45deg);
+            content: '✶';
             position: absolute;
-            top: -15px;
-            right: -30px; /* Adjust as needed to position the flag */
-            width: 20px;
-            height: 20px;
-            background-size: cover;
+            top: -22px;
+            right: -16px;
+            transform: rotate(15deg);
+            font-family: "Press Start 2P", cursive;
+            font-size: 0.7rem;
+            color: rgba(255, 110, 199, 0.8);
+            text-shadow: 0 0 12px rgba(255, 110, 199, 0.9);
         }
 
         .progress-chibi {
             position: absolute;
-            top: -30px;
+            top: -28px;
             left: 0;
-            width: 30px;
-            height: 30px;
+            width: 34px;
+            height: 34px;
             background-size: cover;
+            filter: drop-shadow(0 0 12px rgba(0, 246, 255, 0.65));
         }
 
         @media (max-width: 992px) {
             .card {
                 width: 125px;
                 height: 125px;
+                margin: 1.5em 0;
             }
         }
         @media (max-width: 768px) {
@@ -199,6 +277,7 @@
             .card {
                 width: 100px;
                 height: 100px;
+                margin: 1.2em 0;
             }
         }
         @media (max-width: 567px) {
@@ -208,6 +287,7 @@
             .card {
                 width: 80px;
                 height: 80px;
+                margin: 1em 0;
             }
         }
         @media (max-width: 375px) {
@@ -217,6 +297,7 @@
             .card {
                 width: 75px;
                 height: 75px;
+                margin: 0.8em 0;
             }
         }
 


### PR DESCRIPTION
## Summary
- swap the countdown page to a neon-inspired retro palette with gradients, grid overlays, and glowing typography
- refresh timer cards and progress bars with retro fonts, neon shadows, and updated spacing for better readability

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d35f0dfc7083228cf7589d532994f6