### PR TITLE
Switch countdown page to retro neon aesthetic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,354 +1,871 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Đếm Ngày Trở Về</title>
-    
+    <title>ネオンリバイバル・カウントダウン</title>
+
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Funnel+Display:wght@300..800&display=swap" rel="stylesheet">
-    
+    <link
+        href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Orbitron:wght@400;500;600;700&display=swap"
+        rel="stylesheet">
+
     <style>
-        html {
-            font-size: 14px;
-            font-family: "Funnel Display", sans-serif;
-            font-weight: 400;
-            font-style: normal;
+        :root {
+            --bg-top: #0b0223;
+            --bg-bottom: #170038;
+            --grid-primary: rgba(122, 248, 255, 0.12);
+            --grid-secondary: rgba(255, 113, 212, 0.18);
+            --panel-bg: rgba(9, 0, 33, 0.82);
+            --panel-border: rgba(122, 248, 255, 0.45);
+            --panel-glow: rgba(122, 248, 255, 0.3);
+            --panel-glow-secondary: rgba(255, 113, 212, 0.25);
+            --text-primary: #f8f4ff;
+            --text-muted: #b8a9ff;
+            --accent-pink: #ff71d4;
+            --accent-cyan: #7af8ff;
+            --accent-yellow: #ffe66b;
+            --card-border: rgba(122, 248, 255, 0.4);
+            --card-shadow: 0 18px 32px rgba(3, 0, 19, 0.65);
+            --holiday-border: rgba(255, 113, 212, 0.55);
+            --today-border: rgba(255, 230, 107, 0.75);
+            --transition-default: 220ms ease;
         }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html {
+            font-size: 15px;
+            font-family: "Noto Sans JP", "Hiragino Kaku Gothic ProN", "Meiryo", sans-serif;
+            color: var(--text-primary);
+            background-color: #05000e;
+        }
+
         body {
             margin: 0;
-            font-size: 14px;
-            color: white;
-        }
-        @import url("https://fonts.googleapis.com/css2?family=Red+Hat+Text:wght@700&display=swap");
-
-        .container.bg {
-            background-color: hsl(235, 16%, 14%);
             min-height: 100vh;
-            background-repeat: no-repeat;
-            background-position: top, bottom;
-            background-size: contain;
             display: flex;
             justify-content: center;
             align-items: center;
-            flex-direction: column;
+            padding: clamp(2rem, 4vw, 4rem);
+            background:
+                radial-gradient(circle at 16% 18%, rgba(255, 113, 212, 0.38), transparent 55%),
+                radial-gradient(circle at 84% 0%, rgba(122, 248, 255, 0.32), transparent 60%),
+                linear-gradient(160deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
             position: relative;
+            overflow-x: hidden;
         }
+
+        body::before {
+            content: "";
+            position: fixed;
+            inset: 0;
+            background-image:
+                repeating-linear-gradient(0deg, transparent 0 36px, var(--grid-primary) 36px 37px),
+                repeating-linear-gradient(90deg, transparent 0 36px, var(--grid-secondary) 36px 37px);
+            opacity: 0.55;
+            pointer-events: none;
+            z-index: 0;
+        }
+
+        body::after {
+            content: "";
+            position: fixed;
+            inset: 0;
+            background-image:
+                radial-gradient(var(--accent-cyan) 0.6px, transparent 0.6px),
+                radial-gradient(var(--accent-pink) 0.5px, transparent 0.5px);
+            background-size: 140px 140px, 180px 180px;
+            opacity: 0.18;
+            pointer-events: none;
+            z-index: 1;
+        }
+
+        .container.bg {
+            width: 100%;
+            position: relative;
+            z-index: 2;
+            display: flex;
+            justify-content: center;
+        }
+
         .main-box {
+            width: min(1080px, 100%);
+            padding: clamp(2.5rem, 5vw, 4rem);
+            border-radius: 32px;
+            background: var(--panel-bg);
+            border: 1px solid var(--panel-border);
+            box-shadow: 0 30px 60px rgba(3, 0, 19, 0.75);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .main-box::before {
+            content: "";
+            position: absolute;
+            inset: -32px;
+            border-radius: 48px;
+            background:
+                radial-gradient(circle at 20% 20%, rgba(255, 113, 212, 0.45), transparent 70%),
+                radial-gradient(circle at 80% 0%, rgba(122, 248, 255, 0.4), transparent 65%);
+            filter: blur(24px);
+            opacity: 0.7;
+            z-index: -2;
+        }
+
+        .main-box::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            border-radius: inherit;
+            border: 1px solid var(--panel-border);
+            box-shadow:
+                0 0 22px var(--panel-glow),
+                inset 0 0 26px var(--panel-glow-secondary);
+            pointer-events: none;
+            z-index: -1;
+        }
+
+        .heading {
+            margin: 0 0 clamp(1.6rem, 3vw, 2.5rem);
+            text-align: center;
+            font-size: clamp(1.6rem, 3vw, 2.4rem);
+            letter-spacing: 0.36em;
+            font-weight: 600;
+            color: transparent;
+            background: linear-gradient(90deg, var(--accent-yellow), var(--accent-cyan), var(--accent-pink));
+            -webkit-background-clip: text;
+            background-clip: text;
+            text-transform: uppercase;
+            text-shadow: 0 0 14px rgba(122, 248, 255, 0.6);
+        }
+
+        .intro {
+            margin: 0 auto clamp(2rem, 4vw, 3rem);
+            text-align: center;
+            color: var(--text-muted);
+            max-width: 60ch;
+            line-height: 1.8;
+        }
+
+        .box {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: clamp(1.2rem, 4vw, 2.8rem);
+            margin-bottom: clamp(2.6rem, 5vw, 3.8rem);
+        }
+
+        .card {
+            position: relative;
+            width: clamp(120px, 18vw, 190px);
+            padding: clamp(1.6rem, 3vw, 2.4rem) clamp(1.2rem, 2.5vw, 2.1rem);
+            border-radius: 24px;
+            border: 1px solid var(--card-border);
+            background:
+                linear-gradient(160deg, rgba(26, 7, 58, 0.88) 0%, rgba(47, 11, 84, 0.92) 100%);
+            box-shadow: var(--card-shadow);
             display: flex;
             flex-direction: column;
             align-items: center;
-            margin: 10% 0;
+            gap: 0.8rem;
+            transition: transform var(--transition-default), box-shadow var(--transition-default);
         }
-        .heading {
-            font-size: 2em;
-            letter-spacing: 0.5rem;
+
+        .card::after {
+            content: "";
+            position: absolute;
+            inset: 12px 16px;
+            border-radius: 18px;
+            border: 1px solid rgba(122, 248, 255, 0.18);
+            opacity: 0.7;
+            pointer-events: none;
         }
-        .box {
-            display: flex;
+
+        .card:hover {
+            transform: translateY(-6px);
+            box-shadow:
+                0 28px 48px rgba(0, 0, 0, 0.65),
+                0 0 24px rgba(122, 248, 255, 0.45);
         }
-        .card {
-            margin: 2em 0.5em;
-            height: 150px;
-            width: 150px;
-            position: relative;
-            perspective: 300px;
-        }
-        .card-flip {
-            background-color: hsl(236, 21%, 26%);
-            height: 50%;
-            width: 100%;
-            border-radius: 0.3em;
-        }
+
         .counter {
-            position: absolute;
-            font-size: 4em;
-            font-weight: 800;
-            color: hsl(345, 95%, 68%);
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
+            font-family: "Orbitron", "Noto Sans JP", sans-serif;
+            font-size: clamp(3rem, 6vw, 4rem);
+            letter-spacing: 0.22em;
+            color: var(--accent-cyan);
+            text-shadow:
+                0 0 12px rgba(122, 248, 255, 0.85),
+                0 0 24px rgba(122, 248, 255, 0.45);
         }
-        .denoters {
-            text-align: center;
-            color: rgb(125 123 152);
-            text-transform: uppercase;
-            font-size: 1.2em;
+
+        .counter.changing {
+            color: var(--accent-yellow);
+            animation: counterPulse 0.28s ease;
         }
-        .flipper {
-            animation: flip 0.3s;
-            transform-origin: bottom;
-            position: absolute;
-            top: 0;
-            z-index: 1;
-            display: none;
-            transition: 0.1s;
-        }
-        .card-flip.upper {
-            background: linear-gradient(to top, #2f3145c7, hsl(236, 21%, 26%) 88%);
-        }
-        .card-flip.lower {
-            background: linear-gradient(to bottom, #242635c7, hsl(236, 21%, 26%) 88%);
-        }
-        .card-flip.upper::after {
-            content: "";
-            background: black;
-            height: 0.6em;
-            width: 0.6em;
-            position: absolute;
-            border-top-right-radius: 2em;
-            border-bottom-right-radius: 2em;
-            z-index: 10;
-            top: 50%;
-            transform: translateY(-50%);
-        }
-        .card-flip.lower::before {
-            content: "";
-            background: black;
-            height: 0.6em;
-            width: 0.6em;
-            position: absolute;
-            border-top-left-radius: 2em;
-            border-bottom-left-radius: 2em;
-            z-index: 10;
-            top: 50%;
-            left: 100%;
-            transform: translate(-100%, -50%);
-        }
-        @keyframes flip {
+
+        @keyframes counterPulse {
             0% {
-                transform: rotateX(0deg);
-                opacity: 1;
-            }
-            25% {
-                opacity: 0.9;
+                text-shadow: 0 0 10px rgba(255, 230, 107, 0.3);
+                transform: translateY(0);
             }
             50% {
-                opacity: 0.8;
-            }
-            75% {
-                opacity: 0.7;
+                text-shadow:
+                    0 0 16px rgba(255, 230, 107, 0.8),
+                    0 0 32px rgba(255, 113, 212, 0.3);
+                transform: translateY(-3px);
             }
             100% {
-                transform: rotateX(-180deg);
-                opacity: 0;
+                text-shadow: 0 0 12px rgba(122, 248, 255, 0.85);
+                transform: translateY(0);
             }
         }
 
-        /* Progress bar style */
-        .progress-container {
-    width: 100%;
-    height: 10px;
-    background: 
-        hsl(235, 16%, 30%), /* Base background */
-        radial-gradient(circle, hsl(345, 95%, 68%) 10%, transparent 10%) repeat-x; /* Simulated dashed flight path */
-    border-radius: 10px;
-    margin-top: 2em;
-    position: relative;
-}
-
-.progress-bar {
-    height: 100%;
-    width: 0%;
-    background-color: hsl(345, 95%, 68%);
-    border-radius: 10px;
-    transition: width 1s ease-in-out;
-    position: relative;
-}
-
-        .progress-bar::before {
-            content: '🎌';
-            position: absolute;
-            top: -15px;
-            left: -30px;  /* Adjust as needed to position the flag */
-            width: 20px;
-            height: 20px;
-            background-size: cover;
-        }
-        .progress-bar::after {
-            content: '🚀';
-            transform: rotate(45deg);
-            position: absolute;
-            top: -15px;
-            right: -30px; /* Adjust as needed to position the flag */
-            width: 20px;
-            height: 20px;
-            background-size: cover;
+        .denoters {
+            margin: 0;
+            font-size: 0.95rem;
+            letter-spacing: 0.42em;
+            text-transform: uppercase;
+            color: var(--text-muted);
         }
 
-        .progress-chibi {
+        .calendar-section {
+            display: grid;
+            grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
+            gap: clamp(1.8rem, 4vw, 3rem);
+            align-items: start;
+        }
+
+        .calendar-panel,
+        .holiday-panel {
+            background: rgba(8, 1, 28, 0.72);
+            border: 1px solid rgba(122, 248, 255, 0.35);
+            border-radius: 24px;
+            padding: clamp(1.6rem, 3vw, 2.4rem);
+            box-shadow:
+                0 18px 30px rgba(0, 0, 0, 0.55),
+                0 0 18px rgba(122, 248, 255, 0.22);
+            position: relative;
+        }
+
+        .calendar-panel::after,
+        .holiday-panel::after {
+            content: "";
             position: absolute;
-            top: -30px;
-            left: 0;
-            width: 30px;
-            height: 30px;
-            background-size: cover;
+            inset: 12px;
+            border-radius: 18px;
+            border: 1px solid rgba(122, 248, 255, 0.18);
+            pointer-events: none;
+        }
+
+        .holiday-panel {
+            border-color: var(--holiday-border);
+            box-shadow:
+                0 18px 30px rgba(0, 0, 0, 0.5),
+                0 0 22px rgba(255, 113, 212, 0.25);
+        }
+
+        .holiday-panel::after {
+            border-color: rgba(255, 113, 212, 0.22);
+        }
+
+        .calendar-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: clamp(1.4rem, 2.8vw, 1.8rem);
+        }
+
+        .calendar-header button {
+            width: 44px;
+            height: 44px;
+            border-radius: 50%;
+            border: 1px solid var(--accent-cyan);
+            background: rgba(6, 0, 22, 0.7);
+            color: var(--accent-cyan);
+            font-size: 1.4rem;
+            display: grid;
+            place-items: center;
+            cursor: pointer;
+            transition: transform var(--transition-default), box-shadow var(--transition-default), background-color var(--transition-default), color var(--transition-default);
+            box-shadow: 0 0 12px rgba(122, 248, 255, 0.35);
+        }
+
+        .calendar-header button:hover,
+        .calendar-header button:focus-visible {
+            background: var(--accent-cyan);
+            color: #05000e;
+            transform: translateY(-2px);
+            box-shadow:
+                0 0 18px rgba(122, 248, 255, 0.75),
+                0 0 24px rgba(122, 248, 255, 0.35);
+        }
+
+        .calendar-header button:focus {
+            outline: none;
+        }
+
+        .calendar-header button:focus-visible {
+            outline: 2px solid var(--accent-yellow);
+            outline-offset: 3px;
+        }
+
+        .calendar-month {
+            font-family: "Orbitron", "Noto Sans JP", sans-serif;
+            font-size: clamp(1.4rem, 2.5vw, 1.9rem);
+            letter-spacing: 0.32em;
+            text-transform: uppercase;
+            color: var(--text-primary);
+            text-shadow: 0 0 12px rgba(122, 248, 255, 0.45);
+        }
+
+        .calendar-grid {
+            display: grid;
+            grid-template-columns: repeat(7, minmax(0, 1fr));
+            gap: 0.8rem;
+        }
+
+        .calendar-weekday {
+            text-align: center;
+            font-size: 0.85rem;
+            letter-spacing: 0.35em;
+            color: var(--text-muted);
+            text-transform: uppercase;
+        }
+
+        .calendar-weekday.sunday {
+            color: var(--accent-pink);
+        }
+
+        .calendar-weekday.saturday {
+            color: var(--accent-cyan);
+        }
+
+        .calendar-day {
+            min-height: 92px;
+            border-radius: 18px;
+            background: linear-gradient(150deg, rgba(19, 3, 40, 0.86) 0%, rgba(35, 8, 67, 0.9) 100%);
+            border: 1px solid rgba(122, 248, 255, 0.18);
+            padding: 0.8rem 0.6rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.35rem;
+            position: relative;
+            box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+            transition: border-color var(--transition-default), box-shadow var(--transition-default);
+        }
+
+        .calendar-day.empty {
+            background: transparent;
+            border: none;
+            box-shadow: none;
+        }
+
+        .calendar-day::after {
+            content: "";
+            position: absolute;
+            inset: 10px;
+            border-radius: 12px;
+            border: 1px solid rgba(122, 248, 255, 0.12);
+            pointer-events: none;
+        }
+
+        .calendar-day .day-number {
+            font-family: "Orbitron", "Noto Sans JP", sans-serif;
+            font-size: 1.2rem;
+            letter-spacing: 0.12em;
+        }
+
+        .calendar-day.sunday .day-number {
+            color: var(--accent-pink);
+        }
+
+        .calendar-day.saturday .day-number {
+            color: var(--accent-cyan);
+        }
+
+        .calendar-day .day-holiday {
+            font-size: 0.78rem;
+            letter-spacing: 0.1em;
+            color: var(--accent-pink);
+            text-align: center;
+        }
+
+        .calendar-day.holiday {
+            border-color: var(--holiday-border);
+            box-shadow:
+                0 16px 26px rgba(255, 113, 212, 0.28),
+                0 0 18px rgba(255, 113, 212, 0.25);
+        }
+
+        .calendar-day.holiday .day-number,
+        .calendar-day.holiday .day-holiday {
+            color: var(--accent-pink);
+        }
+
+        .calendar-day.today {
+            border-color: var(--today-border);
+            box-shadow:
+                0 0 18px rgba(255, 230, 107, 0.4),
+                0 0 30px rgba(122, 248, 255, 0.3);
+        }
+
+        .holiday-panel h2 {
+            margin: 0 0 1rem;
+            font-family: "Orbitron", "Noto Sans JP", sans-serif;
+            font-size: 1.3rem;
+            letter-spacing: 0.28em;
+            text-transform: uppercase;
+            color: transparent;
+            background: linear-gradient(90deg, var(--accent-pink), var(--accent-cyan));
+            -webkit-background-clip: text;
+            background-clip: text;
+            text-shadow: 0 0 12px rgba(255, 113, 212, 0.45);
+        }
+
+        .holiday-description {
+            margin: 0 0 1.6rem;
+            color: var(--text-muted);
+            font-size: 0.95rem;
+            line-height: 1.7;
+        }
+
+        .holiday-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .holiday-list li {
+            border-radius: 18px;
+            background: linear-gradient(160deg, rgba(255, 113, 212, 0.18) 0%, rgba(122, 248, 255, 0.12) 100%);
+            border: 1px solid var(--holiday-border);
+            padding: 1rem 1.2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 0.35rem;
+            box-shadow:
+                0 16px 24px rgba(0, 0, 0, 0.45),
+                0 0 18px rgba(255, 113, 212, 0.3);
+        }
+
+        .holiday-date {
+            font-size: 0.88rem;
+            letter-spacing: 0.08em;
+            color: var(--text-muted);
+        }
+
+        .holiday-name {
+            font-size: 1.05rem;
+            letter-spacing: 0.1em;
+            color: var(--text-primary);
+        }
+
+        .holiday-english {
+            font-size: 0.85rem;
+            color: rgba(122, 248, 255, 0.8);
+            letter-spacing: 0.06em;
+        }
+
+        .holiday-list .no-holiday {
+            text-align: center;
+            color: var(--text-muted);
         }
 
         @media (max-width: 992px) {
-            .card {
-                width: 125px;
-                height: 125px;
+            .calendar-section {
+                grid-template-columns: 1fr;
             }
-        }
-        @media (max-width: 768px) {
-            body {
-                font-size: 12px;
-            }
-            .card {
-                width: 100px;
-                height: 100px;
-            }
-        }
-        @media (max-width: 567px) {
-            body {
-                font-size: 9px;
-            }
-            .card {
-                width: 80px;
-                height: 80px;
-            }
-        }
-        @media (max-width: 375px) {
-            body {
-                font-size: 8px;
-            }
-            .card {
-                width: 75px;
-                height: 75px;
+
+            .holiday-panel {
+                order: -1;
             }
         }
 
+        @media (max-width: 768px) {
+            .heading {
+                letter-spacing: 0.28em;
+            }
+
+            .card {
+                width: clamp(120px, 45vw, 180px);
+            }
+
+            .calendar-grid {
+                gap: 0.6rem;
+            }
+
+            .calendar-day {
+                min-height: 86px;
+            }
+        }
+
+        @media (max-width: 560px) {
+            body {
+                padding: clamp(1.5rem, 4vw, 2.5rem);
+            }
+
+            .main-box {
+                padding: clamp(2rem, 5vw, 2.6rem);
+            }
+
+            .heading {
+                font-size: clamp(1.4rem, 6vw, 1.8rem);
+                letter-spacing: 0.22em;
+            }
+
+            .calendar-header button {
+                width: 40px;
+                height: 40px;
+            }
+        }
+
+        @media (max-width: 420px) {
+            html {
+                font-size: 14px;
+            }
+
+            .box {
+                gap: 1rem;
+            }
+
+            .card {
+                width: 100%;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .card,
+            .calendar-header button,
+            .counter {
+                transition: none;
+            }
+
+            .counter.changing {
+                animation: none;
+            }
+        }
     </style>
-    
 </head>
 <body>
     <section class="container bg">
         <div class="main-box">
-            <h1 class="heading">Chúng Ta Còn</h1>
+            <h1 class="heading">ネオンリバイバル・カウントダウン</h1>
+            <p class="intro">80年代のシンセウェーブのようなネオンカラーに包まれながら、旅立ちまでの時間と日本の祝日をチェックしましょう。</p>
             <div class="box">
                 <div class="card">
-                    <div class="card-flip upper"></div>
-                    <div class="card-flip flipper"></div>
                     <span class="counter" id="day-counter">00</span>
-                    <div class="card-flip lower"></div>
-                    <h2 class="denoters">ngày</h2>
+                    <h2 class="denoters">日</h2>
                 </div>
-
                 <div class="card">
-                    <div class="card-flip upper"></div>
-                    <div class="card-flip flipper"></div>
                     <span class="counter" id="hour-counter">00</span>
-                    <div class="card-flip lower"></div>
-                    <h2 class="denoters">giờ</h2>
+                    <h2 class="denoters">時</h2>
                 </div>
-
                 <div class="card">
-                    <div class="card-flip upper"></div>
-                    <div class="card-flip flipper"></div>
                     <span class="counter" id="minute-counter">00</span>
-                    <div class="card-flip lower"></div>
-                    <h2 class="denoters">phút</h2>
+                    <h2 class="denoters">分</h2>
                 </div>
-
                 <div class="card">
-                    <div class="card-flip upper"></div>
-                    <div class="card-flip flipper"></div>
                     <span class="counter" id="second-counter">00</span>
-                    <div class="card-flip lower"></div>
-                    <h2 class="denoters">giây</h2>
+                    <h2 class="denoters">秒</h2>
                 </div>
             </div>
 
-            <!-- Progress Bars -->
-            <div class="progress-container">
-                <div class="progress-bar">
-                    <div class="progress-chibi" id="progress-chibi"></div>
+            <div class="calendar-section">
+                <div class="calendar-panel">
+                    <div class="calendar-header">
+                        <button type="button" id="prev-month" aria-label="前の月"><span aria-hidden="true">〈</span></button>
+                        <div class="calendar-month" id="calendar-month" aria-live="polite" aria-atomic="true"></div>
+                        <button type="button" id="next-month" aria-label="次の月"><span aria-hidden="true">〉</span></button>
+                    </div>
+                    <div class="calendar-grid" id="calendar-grid"></div>
                 </div>
-            </div>
-            <div class="progress-container">
-                <div class="progress-bar">
-                    <div class="progress-chibi" id="progress-chibi-2"></div>
-                </div>
-            </div>
-            <div class="progress-container">
-                <div class="progress-bar">
-                    <div class="progress-chibi" id="progress-chibi-3"></div>
-                </div>
-            </div>
-            <div class="progress-container">
-                <div class="progress-bar">
-                    <div class="progress-chibi" id="progress-chibi-4"></div>
+                <div class="holiday-panel">
+                    <h2>日本の祝日</h2>
+                    <p class="holiday-description">選択した月に響く祝日を、ネオンライトの余韻とともにチェックしましょう。</p>
+                    <ul class="holiday-list" id="holiday-list" aria-live="polite" aria-atomic="true"></ul>
                 </div>
             </div>
         </div>
     </section>
 
-        <script>
-        // Set the start and end dates for the progress bar
-        const startDate = new Date("November 13, 2024 00:00:00").getTime();
-        const endDate = new Date("January 01, 2027 00:00:00").getTime();
-        
-        const numPad = (num, size) => {
-            var s = String(num);
-            while (s.length < (size || 2)) {
-                s = "0" + s;
-            }
-            return s;
-        };
+    <script>
+        const countdownTarget = new Date("January 01, 2027 00:00:00").getTime();
 
-        function secParser(seconds) {
-            let days = Math.floor(seconds / (3600 * 24));
-            seconds -= days * 3600 * 24;
-            let hours = Math.floor(seconds / 3600);
-            seconds -= hours * 3600;
-            let minutes = Math.floor(seconds / 60);
-            seconds -= minutes * 60;
+        const padNumber = (value, size = 2) => String(value).padStart(size, "0");
 
+        function parseSeconds(totalSeconds) {
+            const safeSeconds = Math.max(0, totalSeconds);
+            const days = Math.floor(safeSeconds / (3600 * 24));
+            let remainder = safeSeconds - days * 3600 * 24;
+            const hours = Math.floor(remainder / 3600);
+            remainder -= hours * 3600;
+            const minutes = Math.floor(remainder / 60);
+            const seconds = remainder - minutes * 60;
             return [days, hours, minutes, seconds];
         }
 
-        function flipper(elements, data) {
-            if (time <= 0) clearInterval(id);
-            for (let element in elements) {
-                const flipCard = elements[element].previousSibling.previousSibling;
-                if (elements[element].innerText != data[element]) {
-                    flipCard.setAttribute("style", "display: block;");
-                    elements[element].innerText = numPad(data[element], 2);
-                }
-                setTimeout(() => {
-                    flipCard.setAttribute("style", "display: none;");
-                }, 280);
-            }
-        }
+        const dayCounter = document.getElementById("day-counter");
+        const hourCounter = document.getElementById("hour-counter");
+        const minuteCounter = document.getElementById("minute-counter");
+        const secondCounter = document.getElementById("second-counter");
+        const counters = [dayCounter, hourCounter, minuteCounter, secondCounter];
 
-        function updateProgressBar() {
-            const now = Date.now();
-            const timeLeft = endDate - now;
-            const totalTime = endDate - startDate;
-            const progress = (1 - timeLeft / totalTime) * 100;
-            const progressBars = document.querySelectorAll('.progress-bar');
-            const progressChibis = document.querySelectorAll('.progress-chibi');
+        let remainingSeconds = Math.floor((countdownTarget - Date.now()) / 1000);
 
-            progressBars.forEach((bar, index) => {
-                bar.style.width = progress + "%";
-                progressChibis[index].style.left = progress + "%";
+        const motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+        let prefersReducedMotion = motionQuery.matches;
+
+        if (typeof motionQuery.addEventListener === "function") {
+            motionQuery.addEventListener("change", (event) => {
+                prefersReducedMotion = event.matches;
+            });
+        } else if (typeof motionQuery.addListener === "function") {
+            motionQuery.addListener((event) => {
+                prefersReducedMotion = event.matches;
             });
         }
 
-        const day = document.getElementById("day-counter");
-        const hour = document.getElementById("hour-counter");
-        const minute = document.getElementById("minute-counter");
-        const seconds = document.getElementById("second-counter");
+        const scheduleFrame =
+            typeof window !== "undefined" && typeof window.requestAnimationFrame === "function"
+                ? (callback) => window.requestAnimationFrame(callback)
+                : (callback) => setTimeout(callback, 16);
 
-        // Set the initial time left based on the start date
-        let time = Math.floor((endDate - Date.now()) / 1000); // Time left in seconds
+        const counterTimeouts = new WeakMap();
 
-        const id = setInterval(() => {
-            flipper([day, hour, minute, seconds], secParser(time--));
-            updateProgressBar(); // Update the progress bar every second
-        }, 1000);
+        function updateCounters(values) {
+            counters.forEach((counter, index) => {
+                const newValue = padNumber(values[index]);
+                if (counter.textContent !== newValue) {
+                    counter.textContent = newValue;
+                    counter.classList.remove("changing");
+
+                    const existingTimeout = counterTimeouts.get(counter);
+                    if (existingTimeout) {
+                        clearTimeout(existingTimeout);
+                    }
+
+                    if (!prefersReducedMotion) {
+                        scheduleFrame(() => counter.classList.add("changing"));
+                        const timeoutId = setTimeout(() => {
+                            counter.classList.remove("changing");
+                            counterTimeouts.delete(counter);
+                        }, 300);
+                        counterTimeouts.set(counter, timeoutId);
+                    }
+                }
+            });
+        }
+
+        function tickCountdown() {
+            updateCounters(parseSeconds(remainingSeconds));
+            if (remainingSeconds <= 0) {
+                clearInterval(countdownInterval);
+                return;
+            }
+            remainingSeconds -= 1;
+        }
+
+        const countdownInterval = setInterval(tickCountdown, 1000);
+        tickCountdown();
+
+        const japaneseHolidays = [
+            { date: "2024-01-01", localName: "元日", englishName: "New Year's Day" },
+            { date: "2024-01-08", localName: "成人の日", englishName: "Coming of Age Day" },
+            { date: "2024-02-11", localName: "建国記念の日", englishName: "National Foundation Day" },
+            { date: "2024-02-12", localName: "振替休日 (建国記念の日)", englishName: "Substitute Holiday" },
+            { date: "2024-02-23", localName: "天皇誕生日", englishName: "Emperor's Birthday" },
+            { date: "2024-03-20", localName: "春分の日", englishName: "Vernal Equinox Day" },
+            { date: "2024-04-29", localName: "昭和の日", englishName: "Showa Day" },
+            { date: "2024-05-03", localName: "憲法記念日", englishName: "Constitution Memorial Day" },
+            { date: "2024-05-04", localName: "みどりの日", englishName: "Greenery Day" },
+            { date: "2024-05-05", localName: "こどもの日", englishName: "Children's Day" },
+            { date: "2024-05-06", localName: "振替休日 (こどもの日)", englishName: "Substitute Holiday" },
+            { date: "2024-07-15", localName: "海の日", englishName: "Marine Day" },
+            { date: "2024-08-11", localName: "山の日", englishName: "Mountain Day" },
+            { date: "2024-08-12", localName: "振替休日 (山の日)", englishName: "Substitute Holiday" },
+            { date: "2024-09-16", localName: "敬老の日", englishName: "Respect for the Aged Day" },
+            { date: "2024-09-22", localName: "秋分の日", englishName: "Autumnal Equinox Day" },
+            { date: "2024-09-23", localName: "振替休日 (秋分の日)", englishName: "Substitute Holiday" },
+            { date: "2024-10-14", localName: "スポーツの日", englishName: "Sports Day" },
+            { date: "2024-11-03", localName: "文化の日", englishName: "Culture Day" },
+            { date: "2024-11-04", localName: "振替休日 (文化の日)", englishName: "Substitute Holiday" },
+            { date: "2024-11-23", localName: "勤労感謝の日", englishName: "Labour Thanksgiving Day" },
+            { date: "2025-01-01", localName: "元日", englishName: "New Year's Day" },
+            { date: "2025-01-13", localName: "成人の日", englishName: "Coming of Age Day" },
+            { date: "2025-02-11", localName: "建国記念の日", englishName: "National Foundation Day" },
+            { date: "2025-02-23", localName: "天皇誕生日", englishName: "Emperor's Birthday" },
+            { date: "2025-02-24", localName: "振替休日 (天皇誕生日)", englishName: "Substitute Holiday" },
+            { date: "2025-03-20", localName: "春分の日", englishName: "Vernal Equinox Day" },
+            { date: "2025-04-29", localName: "昭和の日", englishName: "Showa Day" },
+            { date: "2025-05-03", localName: "憲法記念日", englishName: "Constitution Memorial Day" },
+            { date: "2025-05-04", localName: "みどりの日", englishName: "Greenery Day" },
+            { date: "2025-05-05", localName: "こどもの日", englishName: "Children's Day" },
+            { date: "2025-05-06", localName: "振替休日 (こどもの日)", englishName: "Substitute Holiday" },
+            { date: "2025-07-21", localName: "海の日", englishName: "Marine Day" },
+            { date: "2025-08-11", localName: "山の日", englishName: "Mountain Day" },
+            { date: "2025-09-15", localName: "敬老の日", englishName: "Respect for the Aged Day" },
+            { date: "2025-09-23", localName: "秋分の日", englishName: "Autumnal Equinox Day" },
+            { date: "2025-10-13", localName: "スポーツの日", englishName: "Sports Day" },
+            { date: "2025-11-03", localName: "文化の日", englishName: "Culture Day" },
+            { date: "2025-11-23", localName: "勤労感謝の日", englishName: "Labour Thanksgiving Day" },
+            { date: "2025-11-24", localName: "振替休日 (勤労感謝の日)", englishName: "Substitute Holiday" },
+            { date: "2026-01-01", localName: "元日", englishName: "New Year's Day" },
+            { date: "2026-01-12", localName: "成人の日", englishName: "Coming of Age Day" },
+            { date: "2026-02-11", localName: "建国記念の日", englishName: "National Foundation Day" },
+            { date: "2026-02-23", localName: "天皇誕生日", englishName: "Emperor's Birthday" },
+            { date: "2026-03-20", localName: "春分の日", englishName: "Vernal Equinox Day" },
+            { date: "2026-04-29", localName: "昭和の日", englishName: "Showa Day" },
+            { date: "2026-05-03", localName: "憲法記念日", englishName: "Constitution Memorial Day" },
+            { date: "2026-05-04", localName: "みどりの日", englishName: "Greenery Day" },
+            { date: "2026-05-05", localName: "こどもの日", englishName: "Children's Day" },
+            { date: "2026-05-06", localName: "振替休日 (こどもの日)", englishName: "Substitute Holiday" },
+            { date: "2026-07-20", localName: "海の日", englishName: "Marine Day" },
+            { date: "2026-08-11", localName: "山の日", englishName: "Mountain Day" },
+            { date: "2026-09-21", localName: "敬老の日", englishName: "Respect for the Aged Day" },
+            { date: "2026-09-22", localName: "国民の休日", englishName: "Citizen's Holiday" },
+            { date: "2026-09-23", localName: "秋分の日", englishName: "Autumnal Equinox Day" },
+            { date: "2026-10-12", localName: "スポーツの日", englishName: "Sports Day" },
+            { date: "2026-11-03", localName: "文化の日", englishName: "Culture Day" },
+            { date: "2026-11-23", localName: "勤労感謝の日", englishName: "Labour Thanksgiving Day" }
+        ];
+
+        const calendarGrid = document.getElementById("calendar-grid");
+        const calendarMonth = document.getElementById("calendar-month");
+        const holidayList = document.getElementById("holiday-list");
+        const prevMonthButton = document.getElementById("prev-month");
+        const nextMonthButton = document.getElementById("next-month");
+
+        const weekdayLabels = ["日", "月", "火", "水", "木", "金", "土"];
+
+        function formatISODate(date) {
+            return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+        }
+
+        function renderCalendar(current) {
+            const year = current.getFullYear();
+            const month = current.getMonth();
+            const firstDay = new Date(year, month, 1);
+            const daysInMonth = new Date(year, month + 1, 0).getDate();
+            const startWeekday = firstDay.getDay();
+
+            calendarMonth.textContent = `${year}年${month + 1}月`;
+            calendarGrid.innerHTML = "";
+
+            weekdayLabels.forEach((label, index) => {
+                const weekdayCell = document.createElement("div");
+                weekdayCell.classList.add("calendar-weekday");
+                if (index === 0) weekdayCell.classList.add("sunday");
+                if (index === 6) weekdayCell.classList.add("saturday");
+                weekdayCell.textContent = label;
+                calendarGrid.appendChild(weekdayCell);
+            });
+
+            for (let i = 0; i < startWeekday; i += 1) {
+                const emptyCell = document.createElement("div");
+                emptyCell.className = "calendar-day empty";
+                calendarGrid.appendChild(emptyCell);
+            }
+
+            const today = new Date();
+            const todayISO = formatISODate(today);
+
+            for (let day = 1; day <= daysInMonth; day += 1) {
+                const date = new Date(year, month, day);
+                const isoDate = formatISODate(date);
+                const weekday = date.getDay();
+
+                const cell = document.createElement("div");
+                cell.classList.add("calendar-day");
+                if (weekday === 0) cell.classList.add("sunday");
+                if (weekday === 6) cell.classList.add("saturday");
+
+                if (isoDate === todayISO) {
+                    cell.classList.add("today");
+                }
+
+                const dayNumber = document.createElement("span");
+                dayNumber.classList.add("day-number");
+                dayNumber.textContent = day;
+                cell.appendChild(dayNumber);
+
+                const holiday = japaneseHolidays.find((item) => item.date === isoDate);
+                if (holiday) {
+                    cell.classList.add("holiday");
+                    const holidayLabel = document.createElement("span");
+                    holidayLabel.classList.add("day-holiday");
+                    holidayLabel.textContent = holiday.localName;
+                    cell.appendChild(holidayLabel);
+                    cell.title = `${holiday.localName} (${holiday.englishName})`;
+                }
+
+                calendarGrid.appendChild(cell);
+            }
+
+            updateHolidayList(year, month);
+        }
+
+        function updateHolidayList(year, month) {
+            const holidaysThisMonth = japaneseHolidays
+                .filter((holiday) => {
+                    const date = new Date(holiday.date);
+                    return date.getFullYear() === year && date.getMonth() === month;
+                })
+                .sort((a, b) => (a.date > b.date ? 1 : -1));
+
+            holidayList.innerHTML = "";
+
+            if (!holidaysThisMonth.length) {
+                const emptyItem = document.createElement("li");
+                emptyItem.classList.add("no-holiday");
+                emptyItem.textContent = "この月に祝日はありません。";
+                holidayList.appendChild(emptyItem);
+                return;
+            }
+
+            holidaysThisMonth.forEach((holiday) => {
+                const date = new Date(holiday.date);
+                const listItem = document.createElement("li");
+
+                const dateText = document.createElement("span");
+                dateText.classList.add("holiday-date");
+                dateText.textContent = `${date.getMonth() + 1}月${date.getDate()}日 (${weekdayLabels[date.getDay()]})`;
+
+                const nameText = document.createElement("span");
+                nameText.classList.add("holiday-name");
+                nameText.textContent = holiday.localName;
+
+                const englishText = document.createElement("span");
+                englishText.classList.add("holiday-english");
+                englishText.textContent = holiday.englishName;
+
+                listItem.appendChild(dateText);
+                listItem.appendChild(nameText);
+                listItem.appendChild(englishText);
+
+                holidayList.appendChild(listItem);
+            });
+        }
+
+        function changeMonth(offset) {
+            const newMonth = new Date(viewingMonth.getFullYear(), viewingMonth.getMonth() + offset, 1);
+            viewingMonth = newMonth;
+            renderCalendar(viewingMonth);
+        }
+
+        let viewingMonth = new Date();
+        viewingMonth.setDate(1);
+        renderCalendar(viewingMonth);
+
+        prevMonthButton.addEventListener("click", () => changeMonth(-1));
+        nextMonthButton.addEventListener("click", () => changeMonth(1));
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the previous Japanese-inspired visuals with a retro neon palette, grid backdrop, and glowing card styles for the countdown layout
- refresh the calendar and holiday panels to match the new theme and enhance accessibility with updated copy and aria-live regions
- adjust the counter animation logic to respect reduced-motion preferences while keeping the countdown responsive

## Testing
- Not run (static page)


------
https://chatgpt.com/codex/tasks/task_e_68d35f0dfc7083228cf7589d532994f6